### PR TITLE
Add MinitouchAgent stop flag.

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/MinitouchAgent.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/MinitouchAgent.java
@@ -62,6 +62,7 @@ public class MinitouchAgent extends Thread {
     private final InputManagerWrapper inputManager;
     private final WindowManagerWrapper windowManager;
     private final Handler handler;
+    private boolean hasStop = false;
 
     private class PointerEvent {
         long lastMouseDown;
@@ -184,7 +185,7 @@ public class MinitouchAgent extends Thread {
      * Manages the client connection. The client is supposed to be minitouch.
      */
     private void manageClientConnection() {
-        while (true) {
+        while (!hasStop) {
             Log.i(TAG, String.format("Listening on %s", SOCKET));
             LocalSocket clientSocket;
             try {
@@ -194,6 +195,7 @@ public class MinitouchAgent extends Thread {
                 processCommandLoop(clientSocket);
             } catch (IOException e) {
                 e.printStackTrace();
+                break;
             }
         }
     }
@@ -253,6 +255,9 @@ public class MinitouchAgent extends Thread {
                             int delayMs = scanner.nextInt();
                             Thread.sleep(delayMs);
                             break;
+                        case "r":
+                            hasStop = true;
+                            break;
                         default:
                             System.out.println("could not parse: " + cmd);
                     }
@@ -310,5 +315,6 @@ public class MinitouchAgent extends Thread {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        System.exit(0);
     }
 }


### PR DESCRIPTION
This is the problem I encountered. When I did not exit the service correctly, the localserversocket did not shut down correctly. I had to restart the device to solve it. To this end, I added an end flag to turn off the original localserversocket.

```
outputstream.write("r\n");
outputstream.flush()
```

@koral-- 