### PR TITLE
Consider that ClipData is an array

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/query/GetClipboardResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/GetClipboardResponder.java
@@ -67,11 +67,15 @@ public class GetClipboardResponder extends AbstractResponder {
         android.content.ClipboardManager clipboardManager =
                 (android.content.ClipboardManager) Service.getClipboardManager();
         ClipData clipData = clipboardManager.getPrimaryClip();
-        if (clipData != null && clipData.getItemCount() > 0) {
-            ClipData.Item clip = clipData.getItemAt(0);
-            return clip.coerceToText(context.getApplicationContext());
-        } else {
-            return null;
+        if (clipData != null) {
+            for (int i = 0; i < clipData.getItemCount(); i++) {
+                ClipData.Item clipItem = clipData.getItemAt(i);
+                CharSequence clip = clipItem.coerceToText(context.getApplicationContext());
+                if (!clip.toString().isEmpty()) {
+                    return clip;
+                }
+            }
         }
+        return null;
     }
 }


### PR DESCRIPTION
ClipData is an array and I think it is a mistake to always refer to Index0.
As a result of worrying about how to maintain compatibility in the relationship where CharSequence is specified in the return value, I selected the first meaningful string (that is, non-empty string) from the array obtained by getItemCount Re-implemented to return.