### PR TITLE
Fix crash when no browsers are installed

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/util/BrowserUtil.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/util/BrowserUtil.java
@@ -40,7 +40,7 @@ public class BrowserUtil {
     }
 
     public static ResolveInfo filterChooser(ResolveInfo info) {
-        return info.activityInfo.packageName.equals("android") ? null : info;
+        return info == null || info.activityInfo.packageName.equals("android") ? null : info;
     }
 
     public static boolean isSameBrowser(ResolveInfo browserOne, ResolveInfo browserTwo) {


### PR DESCRIPTION
When no browsers are installed, it will currently crash with:
```
System.err: java.lang.NullPointerException: Attempt to read from field 'android.content.pm.ActivityInfo android.content.pm.ResolveInfo.activityInfo' on a null object reference
System.err:   at jp.co.cyberagent.stf.util.BrowserUtil.filterChooser(BrowserUtil.java:43)
System.err:   at jp.co.cyberagent.stf.util.BrowserUtil.getDefaultBrowser(BrowserUtil.java:37)
System.err:   at jp.co.cyberagent.stf.monitor.BrowserPackageMonitor.report(BrowserPackageMonitor.java:87)
System.err:   at jp.co.cyberagent.stf.monitor.BrowserPackageMonitor.peek(BrowserPackageMonitor.java:77)
System.err:   at jp.co.cyberagent.stf.Service$Server$Connection.run(Service.java:371)
System.err:   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
System.err:   at java.util.concurrent.FutureTask.run(FutureTask.java:237)
System.err:   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
System.err:   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
System.err:   at java.lang.Thread.run(Thread.java:761)
```