### PR TITLE
Use GitHub Actions for building APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 18
+        java-version: 17
 
     - name: Build APK
-      run: bash gradlew build
+      run: sh gradlew build
 
     - name: Upload APK
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build APK
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 18
+
+    - name: Build APK
+      run: bash gradlew build
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: app-release
+        path: app/build/outputs/apk/release/app-release.apk
+        retention-days: 90


### PR DESCRIPTION
Hello! Thanks for the awesome project.

I was a little disappointed that you need to build APK manually, so here's a little solution: with this people can build APK in a forked repo just by few clicks in Actions tab, then download it as an Artifact on the workflow page.

Where are APKs in Releases by the way? For some reason they can't be there? Or I'm missing something? 😄 