### PR TITLE
action to cleanup BLE pairings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     - Get/set device ringer mode
     - Check whether an SD card is installed
     - Enable/disable WIFI, Bluetooth and query its status
+    - Cleanup Bluetooth pairings
     - Unlock/relock [KeyGuard](http://developer.android.com/reference/android/app/KeyguardManager.html) (essentially unlocking a device)
     - Acquire/release [WakeLock](http://developer.android.com/reference/android/os/PowerManager.WakeLock.html) (i.e. prevent a device from or allow it to sleep)
     - Invoke key events (with meta key support)

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -46,6 +46,7 @@ import jp.co.cyberagent.stf.proto.Wire;
 import jp.co.cyberagent.stf.query.DoAddAccountMenuResponder;
 import jp.co.cyberagent.stf.query.DoIdentifyResponder;
 import jp.co.cyberagent.stf.query.DoRemoveAccountResponder;
+import jp.co.cyberagent.stf.query.DoCleanBluetoothBondedDevicesResponder;
 import jp.co.cyberagent.stf.query.GetAccountsResponder;
 import jp.co.cyberagent.stf.query.GetBluetoothStatusResponder;
 import jp.co.cyberagent.stf.query.GetBrowsersResponder;
@@ -312,6 +313,9 @@ public class Service extends android.app.Service {
 
                     router.register(Wire.MessageType.DO_REMOVE_ACCOUNT,
                             new DoRemoveAccountResponder(getBaseContext()));
+
+                    router.register(Wire.MessageType.DO_CLEAN_BLUETOOTH_BONDED_DEVICES,
+                        new DoCleanBluetoothBondedDevicesResponder(getBaseContext()));
 
                     router.register(Wire.MessageType.GET_ACCOUNTS,
                             new GetAccountsResponder(getBaseContext()));

--- a/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
@@ -27,23 +27,21 @@ public class DoCleanBluetoothBondedDevicesResponder extends AbstractResponder {
         Wire.DoCleanBluetoothBondedDevicesRequest request =
                 Wire.DoCleanBluetoothBondedDevicesRequest.parseFrom(envelope.getMessage());
 
-        boolean successful = false;
-
         // Return early if the API level is not sufficient
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            return buildResponse(envelope, successful);
+            return buildResponse(envelope, false);
         }
 
         // Return early if Bluetooth is not available
         BluetoothManager bm = (BluetoothManager)context.getSystemService(Context.BLUETOOTH_SERVICE);
         if (bm == null) {
-            return buildResponse(envelope, successful);
+            return buildResponse(envelope, false);
         }
 
         // Return early if cannot get Bluetooth adapter
         BluetoothAdapter ba = bm.getAdapter();
         if (ba == null) {
-            return buildResponse(envelope, successful);
+            return buildResponse(envelope, false);
         }
 
         // Return early if no access to bonded devices
@@ -52,7 +50,7 @@ public class DoCleanBluetoothBondedDevicesResponder extends AbstractResponder {
             pairedDevices = ba.getBondedDevices();
         } catch (SecurityException exception) {
             Log.w(TAG, "Failed to un-pair devices: " + exception.getMessage());
-            return buildResponse(envelope, successful);
+            return buildResponse(envelope, false);
         }
 
         int successCount = 0;
@@ -66,8 +64,7 @@ public class DoCleanBluetoothBondedDevicesResponder extends AbstractResponder {
             }
         }
         Log.d(TAG, "Un-paired " + successCount + " devices successfully");
-        successful = true;
-        return buildResponse(envelope, successful);
+        return buildResponse(envelope, true);
     }
 
     private GeneratedMessageLite buildResponse(Wire.Envelope envelope, boolean successful) {

--- a/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
@@ -1,0 +1,89 @@
+package jp.co.cyberagent.stf.query;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import android.content.Context;
+import android.os.Build;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.util.Log;
+
+import com.google.protobuf.GeneratedMessageLite;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import jp.co.cyberagent.stf.proto.Wire;
+
+
+public class DoCleanBluetoothBondedDevicesResponder extends AbstractResponder {
+    private static final String TAG = DoCleanBluetoothBondedDevicesResponder.class.getSimpleName();
+
+    public DoCleanBluetoothBondedDevicesResponder(Context context) {
+        super(context);
+    }
+
+    @Override
+    public GeneratedMessageLite respond(Wire.Envelope envelope) throws InvalidProtocolBufferException {
+        Wire.DoCleanBluetoothBondedDevicesRequest request =
+                Wire.DoCleanBluetoothBondedDevicesRequest.parseFrom(envelope.getMessage());
+
+        boolean successful = false;
+
+        // Return early if the API level is not sufficient
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            return buildResponse(envelope, successful);
+        }
+
+        // Return early if Bluetooth is not available
+        BluetoothManager bm = (BluetoothManager)context.getSystemService(Context.BLUETOOTH_SERVICE);
+        if (bm == null) {
+            return buildResponse(envelope, successful);
+        }
+
+        // Return early if cannot get Bluetooth adapter
+        BluetoothAdapter ba = bm.getAdapter();
+        if (ba == null) {
+            return buildResponse(envelope, successful);
+        }
+
+        // Return early if no access to bonded devices
+        Set<BluetoothDevice> pairedDevices;
+        try {
+            pairedDevices = ba.getBondedDevices();
+        } catch (SecurityException exception) {
+            Log.w(TAG, "Failed to un-pair devices: " + exception.getMessage());
+            return buildResponse(envelope, successful);
+        }
+
+        int successCount = 0;
+        for (BluetoothDevice device : pairedDevices) {
+            try {
+                Method method = device.getClass().getMethod("removeBond");
+                method.invoke(device);
+                successCount++;
+            } catch (Exception exception) {
+                Log.w(TAG, "Failed to un-pair device: " + device.getAddress());
+            }
+        }
+        Log.d(TAG, "Un-paired " + successCount + " devices successfully");
+        successful = true;
+        return buildResponse(envelope, successful);
+    }
+
+    private GeneratedMessageLite buildResponse(Wire.Envelope envelope, boolean successful) {
+        return Wire.Envelope.newBuilder()
+                .setId(envelope.getId())
+                .setType(Wire.MessageType.DO_CLEAN_BLUETOOTH_BONDED_DEVICES)
+                .setMessage(Wire.DoCleanBluetoothBondedDevicesResponse.newBuilder()
+                        .setSuccess(successful)
+                        .build()
+                        .toByteString())
+                .build();
+    }
+
+
+    @Override
+    public void cleanup() {
+        // No-op
+    }
+}

--- a/app/src/main/proto/wire.proto
+++ b/app/src/main/proto/wire.proto
@@ -11,6 +11,7 @@ enum MessageType {
     DO_WAKE = 4;
     DO_ADD_ACCOUNT_MENU = 24;
     DO_REMOVE_ACCOUNT = 20;
+    DO_CLEAN_BLUETOOTH_BONDED_DEVICES = 32;
     GET_ACCOUNTS = 26;
     GET_BROWSERS = 5;
     GET_CLIPBOARD = 6;
@@ -271,6 +272,12 @@ message GetBluetoothStatusRequest {
 message GetBluetoothStatusResponse {
     required bool success = 1;
     required bool status = 2;
+}
+
+message DoCleanBluetoothBondedDevicesRequest {
+}
+message DoCleanBluetoothBondedDevicesResponse {
+    required bool success = 1;
 }
 
 message GetSdStatusRequest {


### PR DESCRIPTION
This brings capability to remove bonded (paired) bluetooth devices since such functionality is not available in adb command.

Reasons for PR;

* Memory and Storage Consumption: Every paired device's details are stored in the phone's memory and storage. Repeatedly pairing new devices could eventually consume a significant amount of storage, especially if the device information is large or if many devices are paired.
* Performance Impact: As the list of paired devices grows, the Bluetooth service on the phone begin to slow down. Operations like scanning, connecting, and managing the list of paired devices take longer. This could potentially impact the performance of the phone, particularly its Bluetooth functionality.
* User Interface Clutter: The Bluetooth settings menu become cluttered with a long list of paired devices, making it difficult for users to find and manage their frequently used devices.
* Potential for Bugs: Repeatedly pairing and unpairing devices in rapid succession could expose bugs in the Bluetooth stack or in the way individual apps handle Bluetooth connections. This leads to unexpected behaviour, including crashes or memory leaks.
* Limit on Paired Devices: Some Android devices have a limit on the number of devices that can be paired at any given time. While this limit is generally quite high and may not be reached through normal use, automated testing that pairs new devices constantly could potentially hit this limit, leading to failures in pairing new devices or automatic unpairing of older devices.