### PR TITLE
add missing permission for "find me" and improve error handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
@@ -16,10 +15,12 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.DUMP"
       tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/DoCleanBluetoothBondedDevicesResponder.java
@@ -29,18 +29,21 @@ public class DoCleanBluetoothBondedDevicesResponder extends AbstractResponder {
 
         // Return early if the API level is not sufficient
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            Log.e(TAG, "API level is not sufficient");
             return buildResponse(envelope, false);
         }
 
         // Return early if Bluetooth is not available
         BluetoothManager bm = (BluetoothManager)context.getSystemService(Context.BLUETOOTH_SERVICE);
         if (bm == null) {
+            Log.e(TAG, "BluetoothManager is null");
             return buildResponse(envelope, false);
         }
 
         // Return early if cannot get Bluetooth adapter
         BluetoothAdapter ba = bm.getAdapter();
         if (ba == null) {
+            Log.e(TAG, "BluetoothAdapter is null");
             return buildResponse(envelope, false);
         }
 

--- a/app/src/main/java/jp/co/cyberagent/stf/query/SetBluetoothEnabledResponder.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/query/SetBluetoothEnabledResponder.java
@@ -4,6 +4,11 @@ import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.bluetooth.BluetoothManager;
 import android.os.Build;
+import android.util.Log;
+import android.content.pm.PackageManager;
+import android.Manifest;
+import androidx.core.content.ContextCompat;
+
 
 import com.google.protobuf.GeneratedMessageLite;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -11,6 +16,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import jp.co.cyberagent.stf.proto.Wire;
 
 public class SetBluetoothEnabledResponder extends AbstractResponder {
+    private static final String TAG = SetBluetoothEnabledResponder.class.getSimpleName();
+    
     public SetBluetoothEnabledResponder(Context context) {
         super(context);
     }
@@ -21,37 +28,43 @@ public class SetBluetoothEnabledResponder extends AbstractResponder {
                 Wire.SetBluetoothEnabledRequest.parseFrom(envelope.getMessage());
 
         boolean successful;
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            BluetoothManager bm = (BluetoothManager)context.getSystemService(Context.BLUETOOTH_SERVICE);
-            if (bm != null) {
-                BluetoothAdapter ba = bm.getAdapter();
-                if (ba != null) {
-                    try {
-                        if (request.getEnabled()) {
-                            ba.enable();
-                        } else {
-                            ba.disable();
-                        }
-                        successful = true;
-                    } catch (SecurityException exception) {
-                        successful = false;
-                    }
-                }
-                // No Bluetooth available
-                else {
-                    successful = false;
-                }
-            }
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            // getAdapter() is only available since Android API level 18
+            Log.e(TAG, "API level is not sufficient");
+            return buildResponse(envelope, false);
+        }
+        BluetoothManager bm = (BluetoothManager)context.getSystemService(Context.BLUETOOTH_SERVICE);
+        if (bm == null) {
             // No Bluetooth available
-            else {
-                successful = false;
+            Log.e(TAG, "BluetoothManager is null");
+            return buildResponse(envelope, false);
+        }
+        BluetoothAdapter ba = bm.getAdapter();
+        if (ba == null) {
+            // No Bluetooth available
+            Log.e(TAG, "BluetoothAdapter is null");
+            return buildResponse(envelope, false);
+        }
+        int dumpPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT);
+        if (dumpPermission == PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "Permission granted to change Bluetooth state");
+        } else {
+            Log.w(TAG, "Permission denied to change Bluetooth state");
+        }
+            
+        try {
+            if (request.getEnabled()) {
+                ba.enable();
+            } else {
+                ba.disable();
             }
+            return buildResponse(envelope, true);
+        } catch (SecurityException exception) {
+            Log.e(TAG, "Failed to set Bluetooth enabled: " + exception.getMessage());
+            return buildResponse(envelope, false);
         }
-        // getAdapter() is only available since Android API level 18
-        else {
-            successful = false;
-        }
-
+    }
+    private GeneratedMessageLite buildResponse(Wire.Envelope envelope, boolean successful) {
         return Wire.Envelope.newBuilder()
                 .setId(envelope.getId())
                 .setType(Wire.MessageType.SET_BLUETOOTH_ENABLED)
@@ -61,6 +74,7 @@ public class SetBluetoothEnabledResponder extends AbstractResponder {
                         .toByteString())
                 .build();
     }
+
 
     @Override
     public void cleanup() {


### PR DESCRIPTION
improve error handling and add required "find me" permission for manifest,

Tested with android 14 and android 9.

Note, require https://github.com/DeviceFarmer/stf/pull/765 to be able to use "find me" and toggle bluetooth state.