### PR TITLE
Fix work on Realme/Oppo on Android 14

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,22 +3,22 @@ name: Android
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - name: Gradle
     task:
       jobs:
         - name: Build
           commands:
-            - wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O ~/android-commandline-tools.zip
+            - sem-version java 17
+            - wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O ~/android-commandline-tools.zip
             - mkdir -p ~/android-sdk/
             - unzip ~/android-commandline-tools.zip -d ~/android-sdk/cmdline-tools/
             - mv ~/android-sdk/cmdline-tools/cmdline-tools/ ~/android-sdk/cmdline-tools/latest
             - export PATH=$PATH:~/android-sdk/cmdline-tools/latest/bin
-            - yes | sdkmanager "ndk;25.2.9519653"
-            - export PATH=$PATH:~/android-sdk/ndk/25.2.9519653/
+            - yes | sdkmanager "ndk;26.3.11579264"
+            - export PATH=$PATH:~/android-sdk/ndk/26.3.11579264/
             - export ANDROID_SDK_ROOT=~/android-sdk
             - checkout
-            - sem-version java 17
             - ./gradlew build
             - artifact push job app/build/outputs/apk/release/app-release.apk

--- a/app/src/main/java/jp/co/cyberagent/stf/Agent.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Agent.java
@@ -36,7 +36,7 @@ public class Agent extends Thread {
 
     public static void main(String[] args) {
         ProcUtil.setArgV0(PROCESS_NAME);
-        Looper.prepare();
+        Looper.prepareMainLooper();
         Handler handler = new Handler();
         for (String arg : args) {
             if (arg.equals("--version")) {


### PR DESCRIPTION
There was a crash happening on Realme, Oppo (Maybe other BBK brands) devices with `TheiaSigprotector`  class on Android 14 during device "_preparing_" to connect.

Same issue [here](https://github.com/RikkaApps/Shizuku/commit/64d2eba161bb5274048101a1fc84e5ed1a7c8b77#diff-90f6e046e226581afec156c4347b1cf27c9812c8b576f8ce5674db2ec695cd9c)

With this fix works fine on Relame 12 Pro 5G

upd. Also tested with Oppo Reno11 F 5G

```
12-31 21:14:14:14.134 5137 5137 E AndroidRuntime: PID: 5137
12-31 21:14:14.14.134 5137 5137 5137 E AndroidRuntime: java.lang.NullPointerException: Attempted to read from field 'android.os.MessageQueue android.os.Looper.mQueue' on a null object reference in method 'void android.os.Handler.<init>(android.os.Looper, android.os.Handler$Callback, boolean, boolean)'
12-31 21:14:14.134 5137 5137 E AndroidRuntime: at android.os.Handler.<init>(Handler.java:264)
12-31 21:21:14:14.134 5137 5137 5137 E AndroidRuntime: at android.os.Handler.<init>(Handler.java:257)
12-31 21:14:14.134 5137 5137 5137 E AndroidRuntime: at android.os.Handler.<init>(Handler.java:162)
12-31 21:14:14.134 5137 5137 5137 E AndroidRuntime: at android.os.TheiaSigprotector.initSigprotector(TheiaSigprotector.java:52)
12-31 21:14:14.134 5137 5137 E AndroidRuntime: at android.os.LooperExtImpl.initLoop(LooperExtImpl.java:65)
12-31 21:14:14.134 5137 5137 5137 E AndroidRuntime: at android.os.Looper.loop(Looper.java:349)
12-31 21:14:14:14.134 5137 5137 E AndroidRuntime: at jp.co.cyberagent.stf.Agent.main(Agent.java:69)
```
