### PR TITLE
fixed red screen for devices reporting kernel_state with an underscore

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -461,7 +461,7 @@ public class Service extends android.app.Service {
                                 currentAdbState = line.split(":").length == 2 ? line.split(":")[1] : "";
                             } else if (line.contains("Kernel state:")) {
                                 currentUsbState = line.split(":").length == 2 ? line.split(":")[1] : "";
-                            }else if (line.toLowerCase().contains("kernel_state")) {
+                            } else if (line.toLowerCase().contains("kernel_state")) {
                                 currentUsbState = line.split("=").length == 2 ? line.split(":")[1] : "";
                             }
                         }

--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -455,13 +455,17 @@ public class Service extends android.app.Service {
                         String currentUsbState = "";
                         String currentAdbState = "";
                         BufferedReader adbdStateReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
                         for (String line = adbdStateReader.readLine(); line != null; line = adbdStateReader.readLine()) {
                             if (line.contains("Current Functions:") || line.contains("mCurrentFunctions:")) {
                                 currentAdbState = line.split(":").length == 2 ? line.split(":")[1] : "";
                             } else if (line.contains("Kernel state:")) {
                                 currentUsbState = line.split(":").length == 2 ? line.split(":")[1] : "";
+                            }else if (line.toLowerCase().contains("kernel_state")) {
+                                currentUsbState = line.split("=").length == 2 ? line.split(":")[1] : "";
                             }
                         }
+
 
                         if (!currentUsbState.equals(lastUsbState)) {
                             Log.d(TAG, "Kernel state changed to" + currentUsbState);


### PR DESCRIPTION
There are devices that report the adb Kernel State  in a different format:
For example:
`USB MANAGER STATE (dumpsys usb):
{
  device_manager={
    handler={
      current_functions=MTP
      current_functions_applied=true
      screen_unlocked_functions=MTP
      screen_locked=false
      connected=true
      configured=true
      host_connected=false
      source_power=false
      sink_power=true
      usb_charging=false
      hide_usb_notification=false
      audio_accessory_connected=false
      kernel_state=CONFIGURED
    }
  }`
  This prevents the currentAdbState to be read correctly and the service detects that the device is not connected, thus triggering the Identity Activity (Red screen)