### PR TITLE
Fixed red screen for devices reporting without adb function

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/stf/Service.java
+++ b/app/src/main/java/jp/co/cyberagent/stf/Service.java
@@ -479,7 +479,7 @@ public class Service extends android.app.Service {
 
                         boolean disconnected = lastUsbState.contains("DISCONNECTED");
                         boolean adbEnabled = lastAdbState.contains("adb");
-                        if (disconnected || !adbEnabled) {
+                        if (disconnected || (!lastAdbState.equals("") && !adbEnabled)) {
                             Log.d(TAG, "Start activity for STFService");
                             getApplication().startActivity(new IdentityActivity.IntentBuilder().build(getApplication()));
                         }


### PR DESCRIPTION
Even when a user uses/owns devices like the Galaxy Note 10(and more) in STF, the red screen appears every 30 seconds.

In "dumpsys usb", there are no "Current Functions:" and "mCurrentFunctions:" strings, so the lastAdbState variable was an empty string.

```
USB MANAGER STATE (dumpsys usb):
USB Host Restrictor State:
  Restrictor mBootCompleted:true
  Restrictor All SIM Count:0
  Restrictor Disable Sys Node Value :OFF
  Restrictor Disable Sys Node Writable :true
  Restrictor mCurrentSysNodeValue :OFF
  Restrictor MPSM ON/OFF :false
  Restrictor MPSM ON/OFF From Intent :false
  Restrictor SUPPORT MPSM :true
  Restrictor SIM BLOCK ON/OFF :false
  Restrictor MDM BLOCK ON/OFF :false
  Restrictor MDM bRestrictHostAPI :false
  Restrictor MDM mStrWhiteList :OFF
Current UsbMonitor state:
Current DexModeObserver state:false
  Notification :
    ready : true
{
  device_manager={
    handler={
      current_functions=[
        MTP
        0x400000
      ]
      current_functions_applied=true
      screen_unlocked_functions=[
        MTP
        0x400000
      ]
      screen_locked=false
      connected=true
      configured=true
      host_connected=false
      source_power=false
      sink_power=true
      usb_charging=true
      hide_usb_notification=false
      audio_accessory_connected=false
      kernel_state=CONFIGURED
      kernel_function_list=mtp,acm,conn_gadget,adb
    }
  }
  host_manager={
    num_connects=0
  }
  port_manager={
    is_simulation_active=false
    usb_ports={
      port={
        id=port0
        supported_modes=dual
      }
      status={
        connected=true
        current_mode=ufp
        power_role=sink
        data_role=device
        role_combinations=[
          {
            power_role=source
            data_role=host
          }
          {
            power_role=sink
            data_role=device
          }
        ]
        contaminant_presence_status=not-supported
      }
      can_change_mode=true
      can_change_power_role=false
      can_change_data_role=false
      connected_at_millis=34655
      last_connect_duration_millis=0
    }
  }
  alsa_manager={
    cards_parser=-1
  }
  ...
}
```

I think, it's sufficient for now, but not good solution.
I'll check for the vaule 0x400000 in "current_function=[] (multi-line)" or other methods..